### PR TITLE
chore: gitignore ignores bin dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ go.work.sum
 
 # binary
 kubernetes-extension
+bin/
 
 # Editor/IDE
 # .idea/


### PR DESCRIPTION
`make build` will build into `bin`, which is currently not gitignores. This fixes that