### PR TITLE
fix: wait works when no conditions set

### DIFF
--- a/pkg/extension/operations.go
+++ b/pkg/extension/operations.go
@@ -70,7 +70,7 @@ func (e *Extension) registerOperations() {
 						Description: "Timeout duration (e.g., 60s, 5m, default: 60s)",
 					},
 				},
-				Required: []string{"apiVersion", "kind", "metadata", "condition"},
+				Required: []string{"apiVersion", "kind", "metadata"},
 			}),
 		),
 		e.handleWait,

--- a/pkg/extension/wait.go
+++ b/pkg/extension/wait.go
@@ -26,9 +26,6 @@ func (e *Extension) handleWait(ctx context.Context, req *sdk.OperationRequest) (
 	}
 
 	condition, _ := args["condition"].(string)
-	if condition == "" {
-		return sdk.Failure(fmt.Errorf("condition is required")), nil
-	}
 
 	status, _ := args["status"].(string)
 	if status == "" {
@@ -66,6 +63,11 @@ func (e *Extension) handleWait(ctx context.Context, req *sdk.OperationRequest) (
 			return false, nil // Keep polling on transient errors
 		}
 
+		// No condition specified — resource exists, that's enough
+		if condition == "" {
+			return true, nil
+		}
+
 		conditions, found, err := unstructured.NestedSlice(obj.Object, "status", "conditions")
 		if err != nil || !found {
 			lastStatus = "NoConditions"
@@ -92,6 +94,16 @@ func (e *Extension) handleWait(ctx context.Context, req *sdk.OperationRequest) (
 	})
 
 	if err != nil {
+		if condition == "" {
+			e.LogError(ctx, "Resource wait timed out", map[string]any{
+				"kind": ref.kind,
+				"name": ref.name,
+			})
+			return sdk.FailureWithMessage(
+				fmt.Sprintf("Resource %s/%s not found", ref.kind, ref.name),
+				fmt.Errorf("timed out waiting for %s/%s to exist", ref.kind, ref.name),
+			), nil
+		}
 		e.LogError(ctx, "Condition wait timed out", map[string]any{
 			"kind":       ref.kind,
 			"name":       ref.name,
@@ -102,6 +114,14 @@ func (e *Extension) handleWait(ctx context.Context, req *sdk.OperationRequest) (
 			fmt.Sprintf("Condition %s=%s not met", condition, status),
 			fmt.Errorf("timed out waiting for %s/%s: last status was %s", ref.kind, ref.name, lastStatus),
 		), nil
+	}
+
+	if condition == "" {
+		e.LogInfo(ctx, "Resource exists", map[string]any{
+			"kind": ref.kind,
+			"name": ref.name,
+		})
+		return sdk.Success(fmt.Sprintf("%s/%s exists", ref.kind, ref.name)), nil
 	}
 
 	e.LogInfo(ctx, "Condition met", map[string]any{

--- a/pkg/extension/wait_test.go
+++ b/pkg/extension/wait_test.go
@@ -2,6 +2,7 @@ package extension
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/mcpchecker/mcpchecker/pkg/extension/sdk"
@@ -65,13 +66,99 @@ func TestHandleWait(t *testing.T) {
 			wantSuccess: false,
 		},
 		{
-			name: "missing condition field",
+			name: "missing condition field checks existence",
 			args: map[string]any{
 				"apiVersion": "v1",
 				"kind":       "Pod",
 				"metadata":   map[string]any{"name": "test"},
+				"timeout":    "1s",
 			},
-			client:      &mockClient{},
+			client: &mockClient{
+				getFn: func(ctx context.Context, gvr schema.GroupVersionResource, name, namespace string) (*unstructured.Unstructured, error) {
+					return &unstructured.Unstructured{
+						Object: map[string]any{
+							"apiVersion": "v1",
+							"kind":       "Pod",
+							"metadata":   map[string]any{"name": "test"},
+						},
+					}, nil
+				},
+			},
+			wantSuccess: true,
+		},
+		{
+			name: "no condition - resource not found times out",
+			args: map[string]any{
+				"apiVersion": "v1",
+				"kind":       "Pod",
+				"metadata":   map[string]any{"name": "test"},
+				"timeout":    "1s",
+			},
+			client: &mockClient{
+				getFn: func(ctx context.Context, gvr schema.GroupVersionResource, name, namespace string) (*unstructured.Unstructured, error) {
+					return nil, fmt.Errorf("not found")
+				},
+			},
+			wantSuccess: false,
+		},
+		{
+			name: "no condition - succeeds when resource exists",
+			args: map[string]any{
+				"apiVersion": "networking.istio.io/v1",
+				"kind":       "Gateway",
+				"metadata":   map[string]any{"name": "my-gateway", "namespace": "istio-system"},
+				"timeout":    "2s",
+			},
+			client: &mockClient{
+				getFn: func(ctx context.Context, gvr schema.GroupVersionResource, name, namespace string) (*unstructured.Unstructured, error) {
+					return &unstructured.Unstructured{
+						Object: map[string]any{
+							"apiVersion": "networking.istio.io/v1",
+							"kind":       "Gateway",
+							"metadata": map[string]any{
+								"name":      "my-gateway",
+								"namespace": "istio-system",
+							},
+							"spec": map[string]any{
+								"selector": map[string]any{
+									"istio": "ingressgateway",
+								},
+							},
+						},
+					}, nil
+				},
+			},
+			wantSuccess: true,
+		},
+		{
+			name: "resource without status.conditions times out (e.g. Istio Gateway)",
+			args: map[string]any{
+				"apiVersion": "networking.istio.io/v1",
+				"kind":       "Gateway",
+				"metadata":   map[string]any{"name": "my-gateway", "namespace": "istio-system"},
+				"condition":  "Available",
+				"status":     "True",
+				"timeout":    "2s",
+			},
+			client: &mockClient{
+				getFn: func(ctx context.Context, gvr schema.GroupVersionResource, name, namespace string) (*unstructured.Unstructured, error) {
+					return &unstructured.Unstructured{
+						Object: map[string]any{
+							"apiVersion": "networking.istio.io/v1",
+							"kind":       "Gateway",
+							"metadata": map[string]any{
+								"name":      "my-gateway",
+								"namespace": "istio-system",
+							},
+							"spec": map[string]any{
+								"selector": map[string]any{
+									"istio": "ingressgateway",
+								},
+							},
+						},
+					}, nil
+				},
+			},
 			wantSuccess: false,
 		},
 	}


### PR DESCRIPTION
Resolves #39 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The `condition` field is now optional for the wait operation; resources can be validated by checking existence alone.
  * Improved timeout and error messaging when resources fail to be found or created within the specified timeout period.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->