### PR TITLE
ci(nightly): correct gh release upload with correct file name

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -99,6 +99,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload artifacts
-        run: gh release upload nightly dist/*.zip dist/*.bundle dist/checksums.txt --clobber
+        run: gh release upload nightly dist/*.zip dist/*.bundle dist/*checksums.txt --clobber
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The nightly releases have been failing due to the name format of the checksums.txt generated by goreleaser. This relaxes the name matching so it should succeed going forwards

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced nightly build artifact upload to handle multiple checksum files more flexibly using improved file pattern matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->